### PR TITLE
fix: schedule language-codes automation and enable pushes

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,15 @@
 name: PHP Workflow
 
 on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
 
 jobs:
   build:

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,8 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-03
+
+- Reviewed and updated workflow automation in `.github/workflows/actions.yml`.
+- Added scheduled trigger (`cron: '0 2 * * 1'`) and `workflow_dispatch` for manual runs.
+- Added workflow token write permission (`permissions: contents: write`).
+- Data refresh is currently blocked by upstream anti-bot protection on LOC endpoint during non-browser fetches; workflow improvements were applied without committing bad output.


### PR DESCRIPTION
## Summary
- added a weekly schedule trigger and `workflow_dispatch` to `.github/workflows/actions.yml`
- added `permissions: contents: write` so workflow commits can push
- added `UPDATE_SCRIPT_MAINTENANCE_REPORT.md` documenting upstream fetch blocker and applied fixes

## Notes
- data regeneration from the LOC endpoint is currently blocked by upstream anti-bot challenge for non-browser fetches, so only safe automation fixes are included