### PR TITLE
Add has_solutions metadata

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -187,5 +187,8 @@
       ]
     }
   ],
-  "collection": "reference-data"
+  "collection": "reference-data",
+  "has_solutions": [
+    "global-country-region-reference-data"
+  ]
 }


### PR DESCRIPTION
Adds `has_solutions` metadata in `datapackage.json` indicating which DataHub Solution package(s) this dataset belongs to:

- global-country-region-reference-data